### PR TITLE
ENH: Option to run without mpi4py

### DIFF
--- a/runtests/mpi/tester.py
+++ b/runtests/mpi/tester.py
@@ -60,7 +60,7 @@ class WorldTooSmall(Exception): pass
 def create_comm(size, mpi_missing='fail'):
     try:
         from mpi4py import MPI
-    except ModuleNotFoundError:
+    except ImportError:
         # If there is no mpi4py and mpi_missing == 'ignore', then return
         # None as a communicator. The test is then responsible for handling
         # this.
@@ -91,7 +91,7 @@ def MPITestFixture(commsize, scope='function', mpi_missing='fail'):
         try:
             from mpi4py import MPI
             MPI.COMM_WORLD.barrier()
-        except ModuleNotFoundError:
+        except ImportError:
             if mpi_missing != 'ignore':
                 raise
         try:
@@ -130,7 +130,7 @@ def MPITest(commsize, mpi_missing='fail'):
     """
     try:
         from mpi4py import MPI
-    except ModuleNotFoundError:
+    except ImportError:
         if mpi_missing != 'ignore':
             raise
         MPI = None
@@ -191,7 +191,7 @@ def MPIWorld(NTask, required=1, optional=False):
     warnings.warn("This function is deprecated, use MPITest instead.", DeprecationWarning)
     try:
         from mpi4py import MPI
-    except ModuleNotFoundError:
+    except ImportError:
         if mpi_missing != 'ignore':
             raise
         MPI = None
@@ -311,7 +311,7 @@ class Tester(BaseTester):
         try:
             from mpi4py import MPI
             return MPI.COMM_WORLD
-        except ModuleNotFoundError:
+        except ImportError:
             if self._mpi_missing == 'ignore':
                 return None
             raise

--- a/runtests/mpi/tester.py
+++ b/runtests/mpi/tester.py
@@ -301,6 +301,7 @@ class Tester(BaseTester):
         extra path : list of str
             extra paths to include on PATH when building
         """
+        self._mpi_missing = 'fail'
         if 'mpi_missing' in kwargs:
             self._mpi_missing = kwargs['mpi_missing']
             del kwargs['mpi_missing']

--- a/runtests/mpi/tester.py
+++ b/runtests/mpi/tester.py
@@ -290,7 +290,7 @@ class Tester(BaseTester):
         parser.addoption("--mpisub-site-dir", default=None, help="site-dir in mpisub")
 
 
-    def __init__(self, *args, mpi_missing='fail', **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         Parameters
         ----------
@@ -301,8 +301,10 @@ class Tester(BaseTester):
         extra path : list of str
             extra paths to include on PATH when building
         """
+        if 'mpi_missing' in kwargs:
+            self._mpi_missing = kwargs['mpi_missing']
+            del kwargs['mpi_missing']
         super(Tester, self).__init__(*args, **kwargs)
-        self._mpi_missing = mpi_missing
 
     @property
     def comm(self):


### PR DESCRIPTION
Runtests now works on systems without mpi4py. This is useful to test codes that are supposed to run in serial and parallel.